### PR TITLE
fix unzip for dgv all variants

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
     "titleBar.inactiveBackground": "#007fff99",
     "titleBar.inactiveForeground": "#e7e7e799"
   },
-  "peacock.color": "#007fff"
+  "peacock.color": "#007fff",
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "event-stream": "^4.0.1",
         "express": "^4.17.1",
         "express-session": "^1.16.1",
-        "extract-zip": "^2.0.0",
         "fs-extra": "^8.1.0",
         "jsonwebtoken": "^8.5.1",
         "method-override": "^3.0.0",
@@ -37,6 +36,7 @@
         "unzipper": "^0.10.14"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.5",
         "@types/axios": "^0.14.0",
         "@types/connect-timeout": "0.0.34",
         "@types/cookie-parser": "^1.4.2",
@@ -46,7 +46,6 @@
         "@types/errorhandler": "0.0.32",
         "@types/event-stream": "^3.3.34",
         "@types/express": "^4.17.1",
-        "@types/extract-zip": "^1.6.2",
         "@types/fs-extra": "^8.1.0",
         "@types/jsonwebtoken": "^8.3.4",
         "@types/method-override": "0.0.31",
@@ -58,7 +57,6 @@
         "@types/rimraf": "^2.0.3",
         "@types/socket.io": "^2.1.4",
         "@types/ssh2": "^0.5.39",
-        "@types/unzipper": "^0.10.1",
         "@typescript-eslint/eslint-plugin": "^2.3.3",
         "@typescript-eslint/parser": "^2.3.3",
         "@typescript-eslint/typescript-estree": "^2.3.3",
@@ -155,6 +153,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/axios": {
       "version": "0.14.0",
@@ -280,12 +287,6 @@
         "@types/range-parser": "*"
       }
     },
-    "node_modules/@types/extract-zip": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@types/extract-zip/-/extract-zip-1.6.2.tgz",
-      "integrity": "sha1-XH60QcQRNhZ6QriLZAUeYmDCnoY=",
-      "dev": true
-    },
     "node_modules/@types/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -390,7 +391,7 @@
       "version": "11.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.3.tgz",
       "integrity": "sha512-5RzvXVietaB8S4dwDjxjltAOHtTO87fiksjqjWGZih97j6KSrdCDaRfmYMNrgrLM87odGBrsTHAl6N3fLraQaw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/p-limit": {
       "version": "2.2.0",
@@ -452,24 +453,6 @@
       "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.6.tgz",
       "integrity": "sha512-NB+SYftagfHTDPdgVyvSZCeg5MURyHECd/PycGIW9hwhnEbTFxIdDbFtf3jxUO3rRnfr0lfdtkZFiv28T1cAsg==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/unzipper": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.1.tgz",
-      "integrity": "sha512-I53zUuPGMR/ry/s61qdlk/NkJHwhekycCqI7IXWFcJHOK+oIFUhnCPT26Wbf4UYNLpFjeujFioXGH+SWY4yUUQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -900,14 +883,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1484,14 +1459,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/engine.io": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
@@ -1952,25 +1919,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
-      "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -1988,14 +1936,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/figures": {
       "version": "2.0.0",
@@ -2199,17 +2139,6 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dependencies": {
         "is-property": "^1.0.2"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/glob": {
@@ -3218,11 +3147,6 @@
         "through": "~2.3"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3300,15 +3224,6 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -4314,15 +4229,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
     },
     "node_modules/yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "event-stream": "^4.0.1",
     "express": "^4.17.1",
     "express-session": "^1.16.1",
-    "extract-zip": "^2.0.0",
     "fs-extra": "^8.1.0",
     "jsonwebtoken": "^8.5.1",
     "method-override": "^3.0.0",
@@ -44,6 +43,7 @@
     "unzipper": "^0.10.14"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.5",
     "@types/axios": "^0.14.0",
     "@types/connect-timeout": "0.0.34",
     "@types/cookie-parser": "^1.4.2",
@@ -53,7 +53,6 @@
     "@types/errorhandler": "0.0.32",
     "@types/event-stream": "^3.3.34",
     "@types/express": "^4.17.1",
-    "@types/extract-zip": "^1.6.2",
     "@types/fs-extra": "^8.1.0",
     "@types/jsonwebtoken": "^8.3.4",
     "@types/method-override": "0.0.31",
@@ -65,7 +64,6 @@
     "@types/rimraf": "^2.0.3",
     "@types/socket.io": "^2.1.4",
     "@types/ssh2": "^0.5.39",
-    "@types/unzipper": "^0.10.1",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
     "@typescript-eslint/typescript-estree": "^2.3.3",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,10 @@
-import { bioGrch38Pool, inCnvPool, dbPool } from './config/database.config';
+import { bioGrch38Pool, inCnvPool, dbPool, bioGrch37Pool } from './config/database.config';
 /** Third Party Packages **/
 import http from 'http';
 import express from 'express';
 import { App } from './app';
 import * as config from './db-env';
-import { updateDatasource } from './datasources/scripts/update-datasource';
-import { bioGrch37Pool } from './config/database.config';
-class Server {
+import { updateDatasource } from './datasources/scripts/update-datasource'; class Server {
   port: number;
   hostname: string;
   server: http.Server;

--- a/test/sql.ts
+++ b/test/sql.ts
@@ -1,4 +1,3 @@
-import { UserDao } from '../src/databases/incnv/dao/user.dao';
 import * as mysql from 'mysql2/promise';
 import { inCnvPool } from '../src/configs/database';
 


### PR DESCRIPTION
- Don't know why `unzipper` package cannot unzip `dev_all_variants.zip correctly`. The file's content is weird. Now change to `adm-zip` package. Please focus only  `src/datasources/scripts/update-dgv-all-varaint.ts`
- Remove some unused modules.